### PR TITLE
Fix UniqueIdVersion enum can not be None

### DIFF
--- a/custom_components/powertag_gateway/__init__.py
+++ b/custom_components/powertag_gateway/__init__.py
@@ -43,10 +43,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     unique_id_version_val = entry.data.get(CONF_DEVICE_UNIQUE_ID_VERSION)
     if unique_id_version_val is None:
-        _LOGGER.warning(
-            "Using older version of device's unique ID, "
-            "may cause conflicts with duplicate serials."
-        )
         unique_id_version = UniqueIdVersion.V0
     else:
         unique_id_version = UniqueIdVersion(unique_id_version_val)

--- a/custom_components/powertag_gateway/__init__.py
+++ b/custom_components/powertag_gateway/__init__.py
@@ -41,13 +41,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     type_of_gateway = [t for t in TypeOfGateway if t.value == type_of_gateway_string][0]
 
-    unique_id_version = UniqueIdVersion(entry.data.get(CONF_DEVICE_UNIQUE_ID_VERSION))
-    if unique_id_version is None:
+    unique_id_version_val = entry.data.get(CONF_DEVICE_UNIQUE_ID_VERSION)
+    if unique_id_version_val is None:
         _LOGGER.warning(
             "Using older version of device's unique ID, "
             "may cause conflicts with duplicate serials."
         )
         unique_id_version = UniqueIdVersion.V0
+    else:
+        unique_id_version = UniqueIdVersion(unique_id_version_val)
 
     try:
         client = await SchneiderModbus.create(host, type_of_gateway, port)


### PR DESCRIPTION
Component fails to start if entry.data.get(CONF_DEVICE_UNIQUE_ID_VERSION) is None.
This fix makes sure the None value is checked before casting it to Enum.